### PR TITLE
Fixes for Slack compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,12 @@ Only one of these may be used. `--choose` is the default.
     If specified, normally hidden profiles (i.e.: has a name starting in ".") will be included in the resulting list/prompt.
 
     When used with --new, the given configuration will also be embedded into the generated XDG Desktop file.
+
+* `--suppress-info`
+
+    If specified, prevents info messages from printing to output.
+
+    This is useful when using the program a protocol handler if certain applications (e.g.: Slack) treat log output as a launch failure.
 ## Licence
 
 See LICENSE file

--- a/qutebrowser-profile
+++ b/qutebrowser-profile
@@ -392,7 +392,7 @@ elif [ $choose -eq 1 ]; then
 
   dmenuArgs="-p qutebrowser"
 
-  [ $rofi -eq 1 ] && dmenuArgs="$dmenuArgs -mesg ${qbArgs:-}"
+  [ $rofi -eq 1 ] && dmenuArgs="$dmenuArgs -mesg $(echo "${qbArgs:-}" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g; s/"/\&quot;/g; s/'"'"'/\&#39;/g')"
 
   [ $onlyExisting -eq 1 ] && dmenuArgs="$dmenuArgs -no-custom"
 

--- a/qutebrowser-profile
+++ b/qutebrowser-profile
@@ -87,6 +87,12 @@ ADDITIONAL ARGUMENTS
     If specified, normally hidden profiles (i.e.: has a name starting in ".")
     will be included in the resulting list/prompt.
 
+  --suppress-info
+    If specified, prevents info messages from printing to output.
+
+    This is useful when using the program a protocol handler if certain
+    applications (e.g.: Slack) treat log output as a launch failure.
+
 Version $QP_VERSION
 This fork is maintained by Christopher Crockett (https://github.com/chaorace/qutebrowser-profile)
 Base package written by Jonny Tyers (https://github.com/jtyers/qutebrowser-profile)
@@ -240,7 +246,7 @@ runQb() {
       || warningMessage $(printf "$errorMsg" $session qtwebengine_dictionaries)
   fi
 
-  echo "using basedir $basedir"
+  infoMessage "using basedir $basedir"
 
   # Launch qutebrowser with a unique app ID for each profile.
   # X11 uses the  --qt-arg name to set WM_CLASS
@@ -254,8 +260,15 @@ runQb() {
 }
 
 runQbNoProfile() {
-  echo "launching without any profile"
+  infoMessage "launching without any profile"
   $qutebrowser $setFlags ${qbArgs[@]} &>/dev/null &
+}
+
+infoMessage() {
+  msg="$@"
+  if [ $echoInfo -eq 1 ]; then
+    echo "$msg"
+  fi
 }
 
 # show a warning message, without exiting
@@ -275,6 +288,7 @@ warningMessage() {
 
 #uid=$(id -u)
 profilesRoot="$XDG_DATA_HOME/qutebrowser" #"/run/user/$uid/qutebrowser"
+echoInfo=1
 choose=0
 allowNoProfile=0
 noProfileName="default"
@@ -301,6 +315,7 @@ else
       --help|-h) echo "$help"; exit 0 ;;
       --qutebrowser) qutebrowser="$2"; shift; shift ;;
       --dmenu) dmenu="$2"; shift; shift ;;
+      --suppress-info) echoInfo=0; shift ;;
       
       --list|-l) list=1; shift ;;
       --choose|-c) choose=1; shift ;;
@@ -414,7 +429,7 @@ elif [ -n "$new" ]; then
   [ -n "$load" ] && die "cannot use --load with --new"
 
   createDesktopFile "$new"
-  echo "qutebrowser profile '$new' created."
+  infoMessage "qutebrowser profile '$new' created."
 
   runQbWithProfile "$new"
 fi

--- a/qutebrowser-profile.desktop
+++ b/qutebrowser-profile.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=qutebrowser-profile
 Comment=Open with qutebrowser-profile
-Exec=qutebrowser-profile --choose %U
+Exec=qutebrowser-profile --suppress-info --choose %U
 Type=Application
 Categories=Network;WebBrowser;
 


### PR DESCRIPTION
Slack likes to try deciding for itself which protocol handler to use for opening web links instead of trusting the choice of `xdg-open`. It starts using the expected protocol handler, but gives up and tries other strategies if it thinks that the handler failed. Regretably, Slack's "failure detection" is not very good! It seems to think that _anything_ printed to stdout represents a failure, at least as far as qutebrowser-profile is concerned.

In order to fix this issue, I had to find ways to eliminate prints to stdout originating from qutebrowser-profile which currently occur during normal "happy pathway" usage of the script operating in `--choose` mode. Namely, the following two sources of stdout messages were addressed:
* Incidental info messages printed directly via qutebrowser-profile
* Pango Warning messages sometimes printed when opening certain URLs with Rofi as the profile chooser

To address the incidental info messages, a new `--suppress-info` flag was implemented and added to the XDG Desktop's Exec value. This change should not have any visible impact on the vast majority of use-cases, since most launchers don't care about stdout. Keep in mind that this flag only suppresses incidental messages (e.g.: "launching without any profile") that occur when following the "happy path". Even when using this flag, the application will still print warnings and/or help text and output from child processes will not be suppressed in any way.

The Pango warnings were actually the result of a bug in qutebrowser-profile itself when launching URLs which contain unescaped HTML special characters. Whenever this happened, warnings would print to console and the prompt's URL preview area would be empty. Simply escaping the characters resolves that issue and lets us work correctly with Slack as a nice bonus :smiley: 